### PR TITLE
Improve code readability

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -60,8 +60,14 @@ public class Main extends Application {
     @Override
     public void start(Stage stage) {
         Person p1 = new Person(TASK_FILE_PATH_CSV, NOTE_FILE_PATH_CSV);
-        Yapper y1 = new Yapper(CHATBOT_NAME, p1.getTaskList(), p1.getNoteList(), p1.getTaskFile(), p1.getNoteFile(),
-                p1.getTaskFileManager(), p1.getNoteFileManager());
+        Yapper y1 = new Yapper(
+                CHATBOT_NAME,
+                p1.getTaskList(),
+                p1.getNoteList(),
+                p1.getTaskFile(),
+                p1.getNoteFile(),
+                p1.getTaskFileManager(),
+                p1.getNoteFileManager());
 
         assert y1 != null : ASSERT_YAPPER_NOT_NULL_STRING;
         assert p1 != null : ASSERT_PERSON_NOT_NULL_STRING;

--- a/src/main/java/yapper/commands/RescheduleCommand.java
+++ b/src/main/java/yapper/commands/RescheduleCommand.java
@@ -68,17 +68,23 @@ public class RescheduleCommand implements Command {
      */
     @Override
     public boolean execute(ArrayList<String> responseList) {
+
         ScheduleTask oldTask = (ScheduleTask) this.taskList.get(this.idx);
         LocalDateTime[] newDateTime = new LocalDateTime[RESCHEDULE_COMMAND_MAX_DTL_ARGS];
+
         for (int i = 0; i < newDateTimeString.length; i++) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DTF_FORMATTER_STRING);
             newDateTime[i] = LocalDateTime.parse(this.newDateTimeString[i], formatter);
         }
+
         ScheduleTask rescheduledTask = oldTask.reschedule(newDateTime);
+
         assert rescheduledTask != null : ASSERT_TASK_IS_NULL_STRING;
+
         this.taskList.set(this.idx, rescheduledTask);
         responseList.add(EXECUTE_INFO_STRING);
         responseList.add(rescheduledTask.toString());
+
         return true;
     }
 }

--- a/src/main/java/yapper/commands/UnmarkCommand.java
+++ b/src/main/java/yapper/commands/UnmarkCommand.java
@@ -48,6 +48,7 @@ public class UnmarkCommand implements Command {
         responseList.add(UNMARK_INFO_STRING);
         responseList.add(t.toString());
         return true;
+
     }
 
     /**

--- a/src/main/java/yapper/data/task/DeadlineScheduleTask.java
+++ b/src/main/java/yapper/data/task/DeadlineScheduleTask.java
@@ -57,6 +57,7 @@ public class DeadlineScheduleTask extends ScheduleTask {
     @Override
     public ScheduleTask reschedule(LocalDateTime... newDateTime) {
         assert newDateTime.length == 1 : ASSERT_NEW_DATE_TIME_STRING;
+
         return new DeadlineScheduleTask(this.getDescription(), newDateTime[0]);
     }
 }

--- a/src/main/java/yapper/data/task/EventsScheduleTask.java
+++ b/src/main/java/yapper/data/task/EventsScheduleTask.java
@@ -60,7 +60,10 @@ public class EventsScheduleTask extends ScheduleTask {
     @Override
     public String toString() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DTF_FORMATTER_STRING);
-        return String.format(EVENTS_INFO_FORMAT_STRING, super.toString(), this.fromLocalDateTime.format(formatter),
+        return String.format(
+                EVENTS_INFO_FORMAT_STRING,
+                super.toString(),
+                this.fromLocalDateTime.format(formatter),
                 this.toLocalDateTime.format(formatter));
     }
 
@@ -73,6 +76,9 @@ public class EventsScheduleTask extends ScheduleTask {
     @Override
     public ScheduleTask reschedule(LocalDateTime... newDateTime) {
         assert newDateTime.length == 2 : ASSERT_NEW_DATE_TIME_STRING;
-        return new EventsScheduleTask(this.getDescription(), newDateTime[0], newDateTime[1]);
+        return new EventsScheduleTask(
+                this.getDescription(),
+                newDateTime[0],
+                newDateTime[1]);
     }
 }

--- a/src/main/java/yapper/data/task/Task.java
+++ b/src/main/java/yapper/data/task/Task.java
@@ -71,6 +71,9 @@ public class Task implements ContentDisplayable {
      */
     @Override
     public String toString() {
-        return String.format(TASK_INFO_FORMAT_STRING, this.getStatusIcon(), this.getDescription());
+        return String.format(
+                TASK_INFO_FORMAT_STRING,
+                this.getStatusIcon(),
+                this.getDescription());
     }
 }

--- a/src/main/java/yapper/parser/CommandParser.java
+++ b/src/main/java/yapper/parser/CommandParser.java
@@ -536,31 +536,44 @@ public class CommandParser {
         String cmd = fullCmd.split(" ")[0];
         if (CommandOption.fromString(cmd).equals(CommandOption.LIST)) { // list tasks
             return buildListCommand(fullCmd, taskList, noteList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.MARK)) {
             return buildMarkCommand(fullCmd, taskList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.UNMARK)) {
             return buildUnmarkCommand(fullCmd, taskList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.TODO)) {
             return buildToDosCommand(fullCmd, taskList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.DEADLINE)) {
             return buildDeadlineCommand(fullCmd, taskList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.EVENT)) {
             return buildEventCommand(fullCmd, taskList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.DELETE)) {
             return buildDeleteCommand(fullCmd, taskList, noteList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.BYE)) {
             return buildByeCommand(fullCmd, taskList, noteList, taskFile, noteFile, taskFileManager, noteFileManager);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.HELP)) {
             return buildHelpCommand();
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.FIND)) {
             return buildFindCommand(fullCmd, taskList, noteList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.RESCHEDULE)) {
             return buildRescheduleCommand(fullCmd, taskList);
+
         } else if (CommandOption.fromString(cmd).equals(CommandOption.NOTE)) {
             return buildNoteCommand(fullCmd, noteList);
+
         }
 
         assert false : ASSERT_FAIL_STRING;
+
         return null;
     }
 }

--- a/src/main/java/yapper/storage/FileManager.java
+++ b/src/main/java/yapper/storage/FileManager.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-
 /**
  * Represents a file manager to handle file operations.
  */
@@ -50,7 +49,6 @@ public abstract class FileManager {
         fw.close();
     }
 
-
     /**
      * Write CSV headers to file if file is empty
      *
@@ -60,7 +58,9 @@ public abstract class FileManager {
     protected static void writeCsvHeadersToTaskFile(File file, String csvFileHeaderString) throws IOException {
         try (FileWriter fw = new FileWriter(file, true)) {
             if (file.length() == 0) {
-                fw.write(String.format(WRITE_STRING_FORMAT_STRING, csvFileHeaderString));
+                fw.write(String.format(
+                        WRITE_STRING_FORMAT_STRING,
+                        csvFileHeaderString));
             }
         }
     }

--- a/src/main/java/yapper/storage/NoteFileManager.java
+++ b/src/main/java/yapper/storage/NoteFileManager.java
@@ -75,7 +75,13 @@ public class NoteFileManager extends FileManager implements Persistable<Note> {
         try {
             appendToFile(filePath, NOTE_CSV_FILE_HEADERS_STRING, false);
             for (Note n : noteList) {
-                appendToFile(filePath, String.format(WRITE_NOTE_FORMAT_STRING, n.getName(), n.getDescription()), true);
+                appendToFile(
+                        filePath,
+                        String.format(
+                        WRITE_NOTE_FORMAT_STRING,
+                        n.getName(),
+                        n.getDescription()),
+                        true);
             }
         } catch (IOException e) {
             System.out.println(e.getLocalizedMessage());

--- a/src/main/java/yapper/storage/TaskFileManager.java
+++ b/src/main/java/yapper/storage/TaskFileManager.java
@@ -68,30 +68,40 @@ public class TaskFileManager extends FileManager implements Persistable<Task> {
             String taskIsDone = EMPTY_STRING;
             String taskFrom = EMPTY_STRING;
             String taskTo = EMPTY_STRING;
+
             taskType = tokens[0];
             taskDescription = tokens[1];
+
             if (tokens.length > 2) {
                 taskIsDone = tokens[2];
             }
+
             if (tokens.length > 3) {
                 taskFrom = tokens[3];
             }
+
             if (tokens.length > 4) {
                 taskTo = tokens[4]; // task by in EventsTask
             }
+
             switch (taskType) {
+
             case TODOS_COMMAND_STRING:
                 loadToDosTaskFromFile(taskList, taskDescription, taskIsDone);
                 break;
+
             case DEADLINE_COMMAND_STRING:
                 loadDeadlineTaskFromFile(taskList, dtf, taskDescription, taskIsDone, taskTo);
                 break;
+
             case EVENTS_COMMAND_STRING:
                 loadEventsTaskFromFile(taskList, dtf, taskDescription, taskIsDone, taskFrom, taskTo);
                 break;
+
             default:
                 assert false : ASSERT_UNKNOWN_EVENT_TYPE + taskType;
                 break;
+
             }
         }
         s.close();
@@ -111,21 +121,30 @@ public class TaskFileManager extends FileManager implements Persistable<Task> {
         String filePath = file.getName();
         try {
             appendToFile(filePath, TASK_CSV_FILE_HEADERS_STRING, false);
+
             for (Task t : taskList) {
                 if (t instanceof ToDosTask) {
                     saveToDosTaskToFile(filePath, t);
+
                 } else if (t instanceof DeadlineScheduleTask) {
                     saveDeadlineTaskToFile(filePath, t);
+
                 } else if (t instanceof EventsScheduleTask) {
                     saveEventsTaskToFile(filePath, t);
+
                 } else {
                     System.out.println(String.format(ERR_TASK_NOT_ADDED_STRING, t, file.getName()));
+
                 }
+
             }
+
         } catch (IOException e) {
             System.out.println(e.getLocalizedMessage());
             return false;
+
         }
+
         return true;
     }
 
@@ -139,11 +158,15 @@ public class TaskFileManager extends FileManager implements Persistable<Task> {
     private static void saveEventsTaskToFile(String filePath, Task t) throws IOException {
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT_STRING);
         EventsScheduleTask ev = (EventsScheduleTask) t;
-        FileManager.appendToFile(filePath, String.format(
-                WRITE_TASK_FORMAT_STRING,
-                EVENTS_COMMAND_STRING, ev.getDescription(),
-                ev.getStatusIcon(), ev.getFromLocalDateTime().format(dtf),
-                ev.getToLocalDateTime().format(dtf)), true);
+
+        FileManager.appendToFile(
+                filePath,
+                String.format(
+                        WRITE_TASK_FORMAT_STRING,
+                        EVENTS_COMMAND_STRING, ev.getDescription(),
+                        ev.getStatusIcon(), ev.getFromLocalDateTime().format(dtf),
+                        ev.getToLocalDateTime().format(dtf)),
+                true);
     }
 
     /**
@@ -177,6 +200,7 @@ public class TaskFileManager extends FileManager implements Persistable<Task> {
      */
     private static void saveToDosTaskToFile(String filePath, Task t) throws IOException {
         ToDosTask td = (ToDosTask) t;
+
         FileManager.appendToFile(filePath,
                 String.format(
                         WRITE_TASK_FORMAT_STRING,
@@ -199,12 +223,16 @@ public class TaskFileManager extends FileManager implements Persistable<Task> {
      */
     private static void loadEventsTaskFromFile(ArrayList<Task> taskList, DateTimeFormatter dtf, String taskDescription,
             String taskIsDone, String taskFrom, String taskTo) {
+
         LocalDateTime taskFromLocalDateTime = LocalDateTime.parse(taskFrom, dtf);
         LocalDateTime taskToLocalDateTime = LocalDateTime.parse(taskTo, dtf);
+
         EventsScheduleTask ev = new EventsScheduleTask(taskDescription, taskFromLocalDateTime, taskToLocalDateTime);
+
         if (taskIsDone.equals(IS_DONE_SYMBOL)) {
             ev.markAsDone();
         }
+
         taskList.add(ev);
     }
 
@@ -219,11 +247,14 @@ public class TaskFileManager extends FileManager implements Persistable<Task> {
      */
     private static void loadDeadlineTaskFromFile(ArrayList<Task> taskList,
             DateTimeFormatter dtf, String taskDescription, String taskIsDone, String taskTo) {
+
         LocalDateTime taskByLocalDateTime = LocalDateTime.parse(taskTo, dtf);
         DeadlineScheduleTask dl = new DeadlineScheduleTask(taskDescription, taskByLocalDateTime);
+
         if (taskIsDone.equals(IS_DONE_SYMBOL)) {
             dl.markAsDone();
         }
+
         taskList.add(dl);
     }
 
@@ -235,10 +266,12 @@ public class TaskFileManager extends FileManager implements Persistable<Task> {
      * @param taskIsDone      status of ToDosTask
      */
     private static void loadToDosTaskFromFile(ArrayList<Task> taskList, String taskDescription, String taskIsDone) {
+
         ToDosTask td = new ToDosTask(taskDescription);
         if (taskIsDone.equals(IS_DONE_SYMBOL)) {
             td.markAsDone();
         }
+
         taskList.add(td);
     }
 }

--- a/src/main/java/yapper/ui/DialogBox.java
+++ b/src/main/java/yapper/ui/DialogBox.java
@@ -38,11 +38,13 @@ public class DialogBox extends HBox {
      * @param img  The image to display
      */
     private DialogBox(String text, Image img) {
+
         try {
             this.loadFxml();
         } catch (IOException e) {
             e.printStackTrace();
         }
+
         assert dialog != null : ASSERT_EMPTY_DIALOG_LABEL_STRING;
 
         dialog.setText(text);
@@ -59,6 +61,7 @@ public class DialogBox extends HBox {
         fxmlLoader.setController(this);
         fxmlLoader.setRoot(this);
         fxmlLoader.load();
+
     }
 
     /**
@@ -66,7 +69,9 @@ public class DialogBox extends HBox {
      */
     private void flip() {
         ObservableList<Node> tmp = FXCollections.observableArrayList(this.getChildren());
+
         assert tmp != null : ASSERT_EMPTY_OBSERVABLE_LIST_STRING;
+
         Collections.reverse(tmp);
         getChildren().setAll(tmp);
         setAlignment(Pos.TOP_LEFT);

--- a/src/main/java/yapper/ui/MainWindow.java
+++ b/src/main/java/yapper/ui/MainWindow.java
@@ -50,6 +50,7 @@ public class MainWindow extends AnchorPane {
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
     }
 
+
     /**
      * Sets the Yapper object.
      *
@@ -58,6 +59,7 @@ public class MainWindow extends AnchorPane {
     public void setYapper(Yapper y) {
         yapper = y;
     }
+
 
     /**
      * Creates two dialog boxes, one echoing user input and the other containing
@@ -70,18 +72,29 @@ public class MainWindow extends AnchorPane {
         String input = userInput.getText();
         ArrayList<String> responseList = new ArrayList<>(); // List of responses to be displayed to the user
         try {
-            Command command = CommandParser.parse(input, yapper.getTaskList(), yapper.getNoteList(),
-                    yapper.getTaskFile(), yapper.getNoteFile(), yapper.getTaskFileManager(),
+            Command command = CommandParser.parse(
+                    input,
+                    yapper.getTaskList(),
+                    yapper.getNoteList(),
+                    yapper.getTaskFile(),
+                    yapper.getNoteFile(),
+                    yapper.getTaskFileManager(),
                     yapper.getNoteFileManager());
+
             command.execute(responseList);
+
         } catch (InvalidCommandSyntaxException | IndexOutOfBoundsException | IllegalArgumentException e) {
             this.addResponses(responseList, e.getMessage());
+
         }
+
         assert responseList.size() > 0 : ASSERT_RESPONSE_LIST_EMPTY;
 
         this.displayResponses(input, responseList.toArray(new String[0]));
+
         userInput.clear();
     }
+
 
     /**
      * Adds multiple responses to the response list using varargs.
@@ -92,6 +105,7 @@ public class MainWindow extends AnchorPane {
     private void addResponses(List<String> responseList, String... messages) {
         responseList.addAll(Arrays.asList(messages));
     }
+
 
     /**
      * Displays the user input and Yapper's response in the dialog container.
@@ -104,7 +118,9 @@ public class MainWindow extends AnchorPane {
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),
                 DialogBox.getYapperDialog(fullResponseString, yapperImage));
+
     }
+
 
     /**
      * Displays Yapper's greeting in the dialog container.
@@ -112,5 +128,6 @@ public class MainWindow extends AnchorPane {
     public void displayChatbotGreeting() {
         String greeting = Ui.printGreet(yapper.getName());
         dialogContainer.getChildren().add(DialogBox.getYapperDialog(greeting, yapperImage));
+
     }
 }


### PR DESCRIPTION
Add newlines to several areas across all files to improve code readability. 
- Method calls with > 4 parameters separate each parameter into a new line
- `assert` statements are clearly separated from regular code for easier visibility when viewing the code
- Newline added before a closing parathesis `}` for large methods

These implementations aim to improve code readability and make it easier to locate `assert` test statements